### PR TITLE
smoltcp Support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,8 @@
+[target.thumbv7m-none-eabi]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7m-none-eabi"

--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,25 @@
+define hook-quit
+    set confirm off
+end
+
+target remote :3333
+# target extended-remote /dev/cu.usbmodemC1E98D01
+# mon swdp_scan
+# att 1
+
+monitor arm semihosting enable
+
+# # send captured ITM to the file itm.fifo
+# # (the microcontroller SWO pin must be connected to the programmer SWO pin)
+# # 8000000 must match the core clock frequency
+# monitor tpiu config internal itm.fifo uart off 8000000
+
+# # OR: make the microcontroller SWO pin output compatible with UART (8N1)
+# # 2000000 is the frequency of the SWO pin
+# monitor tpiu config external uart off 8000000 2000000
+
+# # enable ITM port 0
+# monitor itm port 0 on
+
+load
+continue

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ optional = true
 cortex-m-rt = "0.6.7"
 cortex-m = "0.5.8"
 panic-semihosting = "0.5.1"
-stm32f1xx-hal = { git = "https://github.com/stm32-rs/stm32f1xx-hal.git", features = ["stm32f103", "rt"] }
+stm32f1xx-hal = { git = "https://github.com/stm32-rs/stm32f1xx-hal.git", rev = "c7a5750", features = ["stm32f103", "rt"] }
 
 [[example]]
 name = "smoltcp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ git = "https://github.com/japaric/owning-slice"
 
 [dependencies.smoltcp]
 default-features = false
-features = ["proto-ipv4", "socket-tcp"]
-version = "0.5.0"
+features = ["proto-ipv4", "socket-tcp", "ethernet"]
+version = "0.6.0"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,17 +29,21 @@ version = "1.2.1"
 [dependencies.owning-slice]
 git = "https://github.com/japaric/owning-slice"
 
+[dependencies.smoltcp]
+default-features = false
+features = ["proto-ipv4", "socket-tcp"]
+version = "0.5.0"
+optional = true
+
 [dev-dependencies]
 cortex-m-rt = "0.6.7"
 cortex-m = "0.5.8"
 panic-semihosting = "0.5.1"
 stm32f1xx-hal = { git = "https://github.com/stm32-rs/stm32f1xx-hal.git", features = ["stm32f103", "rt"] }
-smoltcp = { git = "https://github.com/m-labs/smoltcp.git", default-features = false, features = ["proto-ipv4", "socket-tcp"] }
 
-[profile.release]
-debug = true
-opt-level = "s"
-lto = true
+[[example]]
+name = "smoltcp"
+required-features = ["smoltcp"]
 
 [profile.dev]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ git = "https://github.com/japaric/owning-slice"
 [dependencies.smoltcp]
 default-features = false
 features = ["proto-ipv4", "socket-tcp"]
-version = "0.5.0"
+version = "0.7.0"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ version = "0.3.0"
 [dependencies]
 as-slice = "0.1.0"
 
-[dependencies]
-cortex-m-semihosting = "0.3.2"
-
 [dependencies.cast]
 default-features = false
 version = "0.2.2"
@@ -37,8 +34,7 @@ cortex-m-rt = "0.6.7"
 cortex-m = "0.5.8"
 panic-semihosting = "0.5.1"
 stm32f1xx-hal = { git = "https://github.com/stm32-rs/stm32f1xx-hal.git", features = ["stm32f103", "rt"] }
-smoltcp = { version = "0.5.0", default-features = false, features = ["proto-ipv4", "socket-tcp", "log", "verbose"] }
-log = "0.4.6"
+smoltcp = { git = "https://github.com/m-labs/smoltcp.git", default-features = false, features = ["proto-ipv4", "socket-tcp"] }
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ version = "0.3.0"
 [dependencies]
 as-slice = "0.1.0"
 
+[dependencies]
+cortex-m-semihosting = "0.3.2"
+
 [dependencies.cast]
 default-features = false
 version = "0.2.2"
@@ -28,3 +31,19 @@ version = "1.2.1"
 
 [dependencies.owning-slice]
 git = "https://github.com/japaric/owning-slice"
+
+[dev-dependencies]
+cortex-m-rt = "0.6.7"
+cortex-m = "0.5.8"
+panic-semihosting = "0.5.1"
+stm32f1xx-hal = { git = "https://github.com/stm32-rs/stm32f1xx-hal.git", features = ["stm32f103", "rt"] }
+smoltcp = { version = "0.5.0", default-features = false, features = ["proto-ipv4", "socket-tcp", "log", "verbose"] }
+log = "0.4.6"
+
+[profile.release]
+debug = true
+opt-level = "s"
+lto = true
+
+[profile.dev]
+opt-level = "s"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,23 @@
 
 ## [API documentation](https://docs.rs/enc28j60)
 
-## Examples
+## Example
 
-You should find some examples in the [`stm32f103xx-hal`] crate.
+Example program on a STM32F1xx (bluepill) using a ST-Link V2.  
+See the [Rust Embedded Book](https://docs.rust-embedded.org/book/intro/install.html) or [STM32F1xx-hal](https://github.com/stm32-rs/stm32f1xx-hal) for setup details.
 
-[`stm32f103xx-hal`]: https://github.com/japaric/stm32f103xx-hal/tree/master/examples
+Attach OpenOCD to dongle:
+
+```sh
+openocd -f interface\stlink.cfg -f target\stm32f1x.cfg
+```
+
+Flash and Run:
+```sh
+cargo run --features=smoltcp --example smoltcp
+```
+
+Ping or navigate a web-browser to the IP address in `examples/smoltcp.rs`.
 
 ## License
 

--- a/examples/smoltcp.rs
+++ b/examples/smoltcp.rs
@@ -1,0 +1,312 @@
+//! ENC28J60 demo: pong server + UDP echo server
+//!
+//! This program:
+//!
+//! - Responds to ARP requests
+//! - Responds to ICMP echo requests, thus you can `ping` the device
+//! - Responds to *all* UDP datagrams by sending them back
+//!
+//! You can test this program by running the following commands:
+//!
+//! - `ping 192.168.1.33`. The device should respond and toggle the state of the LED on every `ping`
+//! request.
+//! - `nc -u 192.168.1.33 1337` and sending any string. The device should respond back by sending
+//! back the received string; the LED will toggle each time a UDP datagram is sent.
+//!
+#![no_std]
+#![no_main]
+
+extern crate cortex_m_rt as rt;
+#[macro_use]
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate embedded_hal;
+extern crate enc28j60;
+extern crate log;
+extern crate panic_semihosting;
+extern crate smoltcp;
+extern crate stm32f1xx_hal as hal;
+
+use core::fmt::Write;
+use core::intrinsics::transmute;
+use cortex_m_semihosting::hio;
+use embedded_hal::blocking;
+use embedded_hal::digital::{InputPin, OutputPin};
+use enc28j60::{Enc28j60, IntPin, ResetPin};
+use hal::delay::Delay;
+use hal::device;
+use hal::prelude::*;
+use hal::serial::Serial;
+use hal::spi::Spi;
+use log::{Level, LevelFilter, Metadata, Record};
+use rt::{entry, exception};
+
+use smoltcp::iface::{EthernetInterfaceBuilder, NeighborCache};
+use smoltcp::phy::{self, Device, DeviceCapabilities};
+use smoltcp::socket::{SocketSet, TcpSocket, TcpSocketBuffer};
+use smoltcp::time::Instant;
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
+use smoltcp::Result;
+
+/* Constants */
+const KB: u16 = 1024; // bytes
+const SRC_MAC: [u8; 6] = [0x20, 0x18, 0x03, 0x01, 0x00, 0x00];
+
+static mut LOGGER: HioLogger = HioLogger {};
+
+struct HioLogger {}
+
+impl log::Log for HioLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Trace
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            let mut stdout = hio::hstdout().unwrap();
+            writeln!(stdout, "{} - {}", record.level(), record.args()).unwrap();
+        }
+    }
+    fn flush(&self) {}
+}
+
+
+#[entry]
+fn main() -> ! {
+    unsafe {
+        log::set_logger(&LOGGER).unwrap();
+    }
+    log::set_max_level(LevelFilter::Trace);
+
+    let mut cp = cortex_m::Peripherals::take().unwrap();
+    let dp = device::Peripherals::take().unwrap();
+
+    let mut rcc = dp.RCC.constrain();
+    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut flash = dp.FLASH.constrain();
+    let mut gpioa = dp.GPIOA.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpioc = dp.GPIOC.split(&mut rcc.apb2);
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    cp.DWT.enable_cycle_counter();
+
+    // LED
+    let mut led = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
+    // turn the LED off during initialization
+    led.set_high();
+
+    // Serial
+    let mut serial = {
+        let tx = gpiob.pb6.into_alternate_push_pull(&mut gpiob.crl);
+        let rx = gpiob.pb7;
+        let serial = Serial::usart1(
+            dp.USART1,
+            (tx, rx),
+            &mut afio.mapr,
+            115_200.bps(),
+            clocks,
+            &mut rcc.apb2,
+        );
+
+        serial.split().0
+    };
+    writeln!(serial, "serial start").unwrap();
+
+    // SPI
+    let mut ncs = gpioa.pa4.into_push_pull_output(&mut gpioa.crl);
+    ncs.set_high();
+    let sck = gpioa.pa5.into_alternate_push_pull(&mut gpioa.crl);
+    let miso = gpioa.pa6;
+    let mosi = gpioa.pa7.into_alternate_push_pull(&mut gpioa.crl);
+    let spi = Spi::spi1(
+        dp.SPI1,
+        (sck, miso, mosi),
+        &mut afio.mapr,
+        enc28j60::MODE,
+        1.mhz(),
+        clocks,
+        &mut rcc.apb2,
+    );
+    writeln!(serial, "spi initialized").unwrap();
+
+    // ENC28J60
+    let mut reset = gpioa.pa3.into_push_pull_output(&mut gpioa.crl);
+    reset.set_high();
+    let mut delay = Delay::new(cp.SYST, clocks);
+    let mut enc28j60 = Enc28j60::new(
+        spi,
+        ncs,
+        enc28j60::Unconnected,
+        reset,
+        &mut delay,
+        7 * KB,
+        SRC_MAC,
+    )
+    .ok()
+    .unwrap();
+    writeln!(serial, "enc26j60 initialized").unwrap();
+
+    let mut eth = EncPhy::new(enc28j60);
+    writeln!(serial, "eth initialized").unwrap();
+
+    let local_addr = Ipv4Address::new(192, 168, 1, 2);
+    let ip_addr = IpCidr::new(IpAddress::from(local_addr), 24);
+    let mut ip_addrs = [ip_addr];
+    let mut neighbor_storage = [None; 16];
+    let neighbor_cache = NeighborCache::new(&mut neighbor_storage[..]);
+    let ethernet_addr = EthernetAddress(SRC_MAC);
+    let mut iface = EthernetInterfaceBuilder::new(&mut eth)
+        .ethernet_addr(ethernet_addr)
+        .ip_addrs(&mut ip_addrs[..])
+        .neighbor_cache(neighbor_cache)
+        .finalize();
+    writeln!(serial, "iface initialized").unwrap();
+
+    let mut server_rx_buffer = [0; 2048];
+    let mut server_tx_buffer = [0; 2048];
+    let server_socket = TcpSocket::new(
+        TcpSocketBuffer::new(&mut server_rx_buffer[..]),
+        TcpSocketBuffer::new(&mut server_tx_buffer[..]),
+    );
+    let mut sockets_storage = [None, None];
+    let mut sockets = SocketSet::new(&mut sockets_storage[..]);
+    let server_handle = sockets.add(server_socket);
+    writeln!(serial, "sockets initialized").unwrap();
+
+    // LED on after initialization
+    led.set_low();
+
+    // FIXME some frames are lost when sent right after initialization
+    delay.delay_ms(100_u8);
+
+    loop {
+        writeln!(serial, "loop").unwrap();
+        match iface.poll(&mut sockets, Instant::from_millis(0)) {
+            Ok(b) => {
+                writeln!(serial, "Ok({:?})", b).unwrap();
+                if b {
+                    let mut socket = sockets.get::<TcpSocket>(server_handle);
+                    if !socket.is_open() {
+                        socket.listen(80).unwrap();
+                    }
+
+                    if socket.can_send() {
+                        writeln!(serial, "tcp:80 send greeting");
+                        write!(socket, "hello\n").unwrap();
+                        writeln!(serial, "tcp:80 close");
+                        socket.close();
+                    }
+                }
+            }
+            Err(e) => {
+                writeln!(serial, "Error: {:?}", e).unwrap();
+            }
+        }
+    }
+}
+
+struct EncPhy {
+    inner: Enc28j60<
+        hal::spi::Spi<
+            hal::pac::SPI1,
+            (
+                hal::gpio::gpioa::PA5<hal::gpio::Alternate<hal::gpio::PushPull>>,
+                hal::gpio::gpioa::PA6<hal::gpio::Input<hal::gpio::Floating>>,
+                hal::gpio::gpioa::PA7<hal::gpio::Alternate<hal::gpio::PushPull>>,
+            ),
+        >,
+        hal::gpio::gpioa::PA4<hal::gpio::Output<hal::gpio::PushPull>>,
+        enc28j60::Unconnected,
+        hal::gpio::gpioa::PA3<hal::gpio::Output<hal::gpio::PushPull>>,
+    >,
+    rxbuf: [u8; 256],
+}
+
+impl EncPhy {
+    pub fn new(
+        inner: Enc28j60<
+            hal::spi::Spi<
+                hal::pac::SPI1,
+                (
+                    hal::gpio::gpioa::PA5<hal::gpio::Alternate<hal::gpio::PushPull>>,
+                    hal::gpio::gpioa::PA6<hal::gpio::Input<hal::gpio::Floating>>,
+                    hal::gpio::gpioa::PA7<hal::gpio::Alternate<hal::gpio::PushPull>>,
+                ),
+            >,
+            hal::gpio::gpioa::PA4<hal::gpio::Output<hal::gpio::PushPull>>,
+            enc28j60::Unconnected,
+            hal::gpio::gpioa::PA3<hal::gpio::Output<hal::gpio::PushPull>>,
+        >,
+    ) -> Self {
+        EncPhy {
+            inner,
+            rxbuf: [0u8; 256],
+        }
+    }
+}
+
+impl<'a, 'b> Device<'a> for &'b mut EncPhy {
+    type RxToken = PhyRxToken<'a>;
+    type TxToken = PhyTxToken<'a>;
+
+    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+        let len = self.inner.receive(self.rxbuf.as_mut()).ok().unwrap();
+        Some((
+            PhyRxToken(&mut self.rxbuf[..len as usize]),
+            PhyTxToken {
+                enc28j60: &mut self.inner,
+                txbuf: [0u8; 256],
+            },
+        ))
+    }
+
+    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+        self.inner.flush().unwrap();
+        None
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        DeviceCapabilities::default()
+    }
+}
+
+struct PhyRxToken<'a>(&'a [u8]);
+
+impl<'a> phy::RxToken for PhyRxToken<'a> {
+    fn consume<R, F>(self, _timestamp: Instant, f: F) -> Result<R>
+    where
+        F: FnOnce(&[u8]) -> Result<R>,
+    {
+        let result = f(self.0);
+        result
+    }
+}
+
+struct PhyTxToken<'a> {
+    enc28j60: &'a mut enc28j60::Enc28j60<
+        hal::spi::Spi<
+            hal::pac::SPI1,
+            (
+                hal::gpio::gpioa::PA5<hal::gpio::Alternate<hal::gpio::PushPull>>,
+                hal::gpio::gpioa::PA6<hal::gpio::Input<hal::gpio::Floating>>,
+                hal::gpio::gpioa::PA7<hal::gpio::Alternate<hal::gpio::PushPull>>,
+            ),
+        >,
+        hal::gpio::gpioa::PA4<hal::gpio::Output<hal::gpio::PushPull>>,
+        enc28j60::Unconnected,
+        hal::gpio::gpioa::PA3<hal::gpio::Output<hal::gpio::PushPull>>,
+    >,
+    txbuf: [u8; 256],
+}
+
+impl<'a> phy::TxToken for PhyTxToken<'a> {
+    fn consume<R, F>(mut self, _timestamp: Instant, len: usize, f: F) -> Result<R>
+    where
+        F: FnOnce(&mut [u8]) -> Result<R>,
+    {
+        let result = f(&mut self.txbuf[..len]);
+        self.enc28j60.transmit(&self.txbuf[..len]).unwrap();
+        result
+    }
+}

--- a/examples/smoltcp.rs
+++ b/examples/smoltcp.rs
@@ -107,8 +107,9 @@ fn main() -> ! {
     writeln!(serial, "enc26j60 initialized").unwrap();
 
     // PHY Wrapper
-    let mut buf = [0u8; 1024];
-    let mut eth = Phy::new(enc28j60, &mut buf);
+    let mut rx_buf = [0u8; 1024];
+    let mut tx_buf = [0u8; 1024];
+    let mut eth = Phy::new(enc28j60, &mut rx_buf, &mut tx_buf);
     writeln!(serial, "eth initialized").unwrap();
 
     // Ethernet interface
@@ -152,7 +153,7 @@ fn main() -> ! {
 
                     if socket.can_send() {
                         led.toggle();
-                        
+
                         writeln!(serial, "tcp:80 send").unwrap();
                         write!(
                             socket,

--- a/examples/smoltcp.rs
+++ b/examples/smoltcp.rs
@@ -140,6 +140,7 @@ fn main() -> ! {
     // LED on after initialization
     led.set_low();
 
+    let mut count: u64 = 0;
     loop {
         match iface.poll(&mut sockets, Instant::from_millis(0)) {
             Ok(b) => {
@@ -150,20 +151,24 @@ fn main() -> ! {
                     }
 
                     if socket.can_send() {
-                        writeln!(serial, "tcp:80 send").unwrap();
                         led.toggle();
-
+                        
+                        writeln!(serial, "tcp:80 send").unwrap();
                         write!(
                             socket,
-                            "HTTP/1.1 200 OK\r\n\r\nLED is currently: {}\n",
+                            "HTTP/1.1 200 OK\r\n\r\nHello!\nLED is currently {} and has been toggled {} times.\n",
                             match led.is_set_low() {
                                 true => "on",
                                 false => "off",
-                            }
+                            },
+                            count
                         )
                         .unwrap();
+
                         writeln!(serial, "tcp:80 close").unwrap();
                         socket.close();
+
+                        count += 1;
                     }
                 }
             }

--- a/memory.x
+++ b/memory.x
@@ -1,0 +1,6 @@
+/* Linker script for the STM32F103C8T6 */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 128K
+  RAM : ORIGIN = 0x20000000, LENGTH = 20K
+}

--- a/src/bank0.rs
+++ b/src/bank0.rs
@@ -63,7 +63,7 @@ impl Register {
 }
 
 impl Into<crate::Register> for Register {
-    fn into(self) ->crate ::Register {
+    fn into(self) -> crate::Register {
         crate::Register::Bank0(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use byteorder::{ByteOrder, LE};
 use cast::usize;
 use embedded_hal::{
     blocking::{self, delay::DelayMs},
-    digital::{InputPin, OutputPin},
+    digital::v2::{InputPin, OutputPin},
     spi::{Mode, Phase, Polarity},
 };
 use owning_slice::IntoSliceTo;
@@ -330,8 +330,13 @@ where
 
             // status vector
             let status = RxStatus(LE::read_u32(&temp_buf[2..]));
-            let len = status.byte_count() as u16 - CRC_SZ;
+            let byte_count = status.byte_count() as u16;
 
+            if byte_count < CRC_SZ {
+                return Err(Error::CorruptRxBuffer);
+            }
+
+            let len = byte_count - CRC_SZ;
             if len > self.rxnd {
                 return Err(Error::CorruptRxBuffer);
             }
@@ -475,10 +480,10 @@ where
     fn _read_control_register(&mut self, register: Register) -> Result<u8, E> {
         self.change_bank(register)?;
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         let mut buffer = [Instruction::RCR.opcode() | register.addr(), 0];
         self.spi.transfer(&mut buffer)?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(buffer[1])
     }
@@ -506,10 +511,10 @@ where
     fn _write_control_register(&mut self, register: Register, value: u8) -> Result<(), E> {
         self.change_bank(register)?;
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         let buffer = [Instruction::WCR.opcode() | register.addr(), value];
         self.spi.write(&buffer)?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
@@ -593,10 +598,10 @@ where
 
         self.change_bank(register)?;
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi
             .write(&[Instruction::BFC.opcode() | register.addr(), mask])?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
@@ -613,10 +618,10 @@ where
 
         self.change_bank(register)?;
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi
             .write(&[Instruction::BFS.opcode() | register.addr(), mask])?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
@@ -627,18 +632,18 @@ where
             self.write_control_register(bank0::Register::ERDPTH, addr.high())?;
         }
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi.write(&[Instruction::RBM.opcode()])?;
         self.spi.transfer(buf)?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
 
     fn soft_reset(&mut self) -> Result<(), E> {
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi.transfer(&mut [Instruction::SRC.opcode()])?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
@@ -649,10 +654,10 @@ where
             self.write_control_register(bank0::Register::EWRPTH, addr.high())?;
         }
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi.write(&[Instruction::WBM.opcode()])?;
         self.spi.write(buffer)?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
         Ok(())
     }
 }
@@ -683,7 +688,10 @@ where
 
     /// Checks if there's any interrupt pending to be processed by polling the INT pin
     pub fn interrupt_pending(&mut self) -> bool {
-        self.int.is_low()
+        match self.int.is_low() {
+            Ok(_) => true,
+            _ => false,
+        }
     }
 
     /// Stops listening for the specified event
@@ -768,8 +776,8 @@ where
     OP: OutputPin + 'static,
 {
     fn reset(&mut self) {
-        self.set_low();
-        self.set_high();
+        let _ = self.set_low();
+        let _ = self.set_high();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ mod phy;
 mod sealed;
 mod traits;
 
+#[cfg(feature = "smoltcp")]
+pub mod smoltcp_phy;
+
 /// SPI mode
 pub const MODE: Mode = Mode {
     phase: Phase::CaptureOnFirstTransition,

--- a/src/smoltcp_phy.rs
+++ b/src/smoltcp_phy.rs
@@ -1,0 +1,98 @@
+//! todo
+
+use crate::Enc28j60;
+use embedded_hal::{blocking, digital::OutputPin};
+use smoltcp::{
+    phy::{self, Device, DeviceCapabilities},
+    time::Instant,
+};
+
+/// Wrapper for Enc28j60 for use as a `smoltcp` interface
+pub struct Phy<'a, SPI, NCS, INT, RESET> {
+    phy: Enc28j60<SPI, NCS, INT, RESET>,
+    rx_buf: &'a mut [u8],
+}
+
+impl<'a, SPI, NCS, INT, RESET> Phy<'a, SPI, NCS, INT, RESET> {
+    /// Create a new Eth from an Enc28j60 and a receive buffer
+    pub fn new(phy: Enc28j60<SPI, NCS, INT, RESET>, rx_buf: &'a mut [u8]) -> Self {
+        Phy { phy, rx_buf }
+    }
+}
+
+impl<'a, 'b, E, SPI: 'a, NCS: 'a, INT, RESET> Device<'a> for &mut Phy<'b, SPI, NCS, INT, RESET>
+where
+    SPI: blocking::spi::Transfer<u8, Error = E> + blocking::spi::Write<u8, Error = E>,
+    NCS: OutputPin,
+    INT: crate::sealed::IntPin,
+    RESET: crate::sealed::ResetPin,
+{
+    type RxToken = RxToken<'a>;
+    type TxToken = TxToken<'a, SPI, NCS, INT, RESET>;
+
+    fn receive(&'a mut self) -> Option<(Self::RxToken, Self::TxToken)> {
+        let packet = self.phy.next_packet().ok().unwrap();
+        match packet {
+            Some(packet) => {
+                packet.read(&mut self.rx_buf[..]).ok().unwrap();
+                Some((
+                    RxToken(&mut self.rx_buf[..]),
+                    TxToken {
+                        phy: &mut self.phy,
+                        buf: [0u8; 1024],
+                    },
+                ))
+            }
+            None => None,
+        }
+    }
+
+    fn transmit(&'a mut self) -> Option<Self::TxToken> {
+        Some(TxToken {
+            phy: &mut self.phy,
+            buf: [0u8; 1024],
+        })
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut caps = DeviceCapabilities::default();
+        caps.max_transmission_unit = 1500;
+        caps
+    }
+}
+
+/// ?
+pub struct RxToken<'a>(&'a [u8]);
+
+impl<'a> phy::RxToken for RxToken<'a> {
+    fn consume<R, F>(self, _timestamp: Instant, f: F) -> smoltcp::Result<R>
+    where
+        F: FnOnce(&[u8]) -> smoltcp::Result<R>,
+    {
+        let result = f(self.0);
+        result
+    }
+}
+
+/// ?
+pub struct TxToken<'a, SPI, NCS, INT, RESET> {
+    phy: &'a mut Enc28j60<SPI, NCS, INT, RESET>,
+    buf: [u8; 1024],
+}
+
+impl<'a, E, SPI, NCS, INT, RESET> phy::TxToken for TxToken<'a, SPI, NCS, INT, RESET>
+where
+    SPI: blocking::spi::Transfer<u8, Error = E> + blocking::spi::Write<u8, Error = E>,
+    NCS: OutputPin,
+    INT: crate::sealed::IntPin,
+    RESET: crate::sealed::ResetPin,
+{
+    fn consume<R, F>(mut self, _timestamp: Instant, len: usize, f: F) -> smoltcp::Result<R>
+    where
+        F: FnOnce(&mut [u8]) -> smoltcp::Result<R>,
+    {
+        let result = f(&mut self.buf[..len]);
+        self.phy.transmit(&self.buf[..len]).ok().unwrap();
+        result
+    }
+}

--- a/src/smoltcp_phy.rs
+++ b/src/smoltcp_phy.rs
@@ -1,4 +1,4 @@
-//! todo
+//! ENC28J60 wrapper for use as a smoltcp interface
 
 use crate::Enc28j60;
 use embedded_hal::{blocking, digital::OutputPin};
@@ -7,14 +7,14 @@ use smoltcp::{
     time::Instant,
 };
 
-/// Wrapper for Enc28j60 for use as a `smoltcp` interface
+/// Wrapper for use as a `smoltcp` interface for sending and receiving raw network frames.
 pub struct Phy<'a, SPI, NCS, INT, RESET> {
     phy: Enc28j60<SPI, NCS, INT, RESET>,
     rx_buf: &'a mut [u8],
 }
 
 impl<'a, SPI, NCS, INT, RESET> Phy<'a, SPI, NCS, INT, RESET> {
-    /// Create a new Eth from an Enc28j60 and a receive buffer
+    /// Create a new ethernet interface from an Enc28j60 and a receive buffer
     pub fn new(phy: Enc28j60<SPI, NCS, INT, RESET>, rx_buf: &'a mut [u8]) -> Self {
         Phy { phy, rx_buf }
     }
@@ -61,7 +61,7 @@ where
     }
 }
 
-/// ?
+/// A token to receive a single network packet
 pub struct RxToken<'a>(&'a [u8]);
 
 impl<'a> phy::RxToken for RxToken<'a> {
@@ -74,7 +74,7 @@ impl<'a> phy::RxToken for RxToken<'a> {
     }
 }
 
-/// ?
+/// A token to transmit a single network packet.
 pub struct TxToken<'a, SPI, NCS, INT, RESET> {
     phy: &'a mut Enc28j60<SPI, NCS, INT, RESET>,
     buf: [u8; 1024],

--- a/src/smoltcp_phy.rs
+++ b/src/smoltcp_phy.rs
@@ -63,12 +63,12 @@ where
 }
 
 /// A token to receive a single network packet
-pub struct RxToken<'a>(&'a [u8]);
+pub struct RxToken<'a>(&'a mut [u8]);
 
 impl<'a> phy::RxToken for RxToken<'a> {
-    fn consume<R, F>(self, _timestamp: Instant, f: F) -> smoltcp::Result<R>
+    fn consume<R, F>(mut self, _timestamp: Instant, f: F) -> smoltcp::Result<R>
     where
-        F: FnOnce(&[u8]) -> smoltcp::Result<R>,
+        F: FnOnce(&mut [u8]) -> smoltcp::Result<R>,
     {
         let result = f(self.0);
         result

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -56,13 +56,13 @@ impl U16Ext for u16 {
     }
 
     fn be_repr(self) -> [u8; 2] {
-        let mut bytes: [u8; 2] = unsafe { mem::uninitialized() };
+        let mut bytes: [u8; 2] = unsafe { mem::MaybeUninit::uninit().assume_init() };
         BE::write_u16(&mut bytes, self);
         bytes
     }
 
     fn le_repr(self) -> [u8; 2] {
-        let mut bytes: [u8; 2] = unsafe { mem::uninitialized() };
+        let mut bytes: [u8; 2] = unsafe { mem::MaybeUninit::uninit().assume_init() };
         LE::write_u16(&mut bytes, self);
         bytes
     }


### PR DESCRIPTION
This PR adds a wrapper allowing an ENC28J60 to be used with smoltcp, as well as an example that runs a very simple web server.